### PR TITLE
Remove duplicate spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ function clean(fileContent, fileExtension, options) {
     fileContent = fileContent.replace(/<!--[^>]*-->/gm, '');
   }
 
+  if (options.removeSpaces) {
+    fileContent = fileContent.replace(/\s\s+/g, ' ');
+  }
+
   return fileContent.replace(/^\s*[\r\n]/gm, '');
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-remove-empty-lines",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Remove empty lines.",
   "license": "MIT",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -33,10 +33,17 @@ gulp.task('htmlClean', function () {
 
 ##### removeComments
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Remove all the comments from the html files.
+
+##### removeSpaces
+
+Type: `boolean`
+Default: `false`
+
+Remove all duplicate spaces from any file.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -54,3 +54,20 @@ it('Does not remove html comments from javascript files', function (cb) {
 
   stream.end();
 });
+
+it('Remove duplicate spaces', function (cb) {
+  var stream = removeEmptyLines({removeSpaces: true});
+
+  stream.on('data', function (file) {
+    assert.equal(file.contents.toString(), 'test space\ntest2 space\ntest3 space');
+    cb();
+  });
+
+  stream.write(new gutil.File({
+    base: __dirname,
+    path: __dirname + '/index.html',
+    contents: new Buffer('test space\ntest2  space\ntest3   space')
+  }));
+
+  stream.end();
+});


### PR DESCRIPTION
Hello, I use your plugin for native es6 files "minification", so I propose to add an option to clean duplicated spaces. It may be useful for any kind of file: js, "html-in-js", "css-in-js" or just html or css.
