### PR TITLE
Fixed short-circuit evaluation to null in clean()

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 
 function clean(fileContent, fileExtension, options) {
-  fileContent = fileContent.toString() || null;
+  fileContent = fileContent.toString() || '';
   options = options || {};
 
   if (fileExtension === 'html' && options.removeComments) {


### PR DESCRIPTION
The pipe passed an empty string.

events.js:141
      throw er; // Unhandled 'error' event
      ^
TypeError: Cannot read property 'replace' of null
    at clean (.../gulp-remove-empty-lines/index.js:19:21)
